### PR TITLE
Fix gcode_move initialize in toolchanger.py

### DIFF
--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -23,7 +23,7 @@ class Toolchanger:
         self.config = config
         self.gcode_macro = self.printer.load_object(config, 'gcode_macro')
         self.gcode = self.printer.lookup_object('gcode')
-        self.gcode_move = self.printer.lookup_object('gcode_move')
+        self.gcode_move = self.printer.lookup_object(config, 'gcode_move')
 
         self.name = config.get_name()
         self.params = get_params_dict(config)
@@ -225,6 +225,7 @@ class Toolchanger:
 
         self.status = STATUS_CHANGING
         gcode_position = self.gcode_move.get_status()['gcode_position']
+
         extra_context = {
             'dropoff_tool': self.active_tool.name if self.active_tool else None,
             'pickup_tool': tool.name if tool else None,


### PR DESCRIPTION
I was getting the following error when using the toolchanger.py module:

```
Config error
Traceback (most recent call last):
  File "/home/pi/klipper/klippy/klippy.py", line 175, in _connect
    self._read_config()
  File "/home/pi/klipper/klippy/klippy.py", line 141, in _read_config
    self.load_object(config, section_config.get_name(), None)
  File "/home/pi/klipper/klippy/klippy.py", line 130, in load_object
    self.objects[section] = init_func(config.getsection(section))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/klipper/klippy/extras/tool.py", line 140, in load_config_prefix
    return Tool(config)
           ^^^^^^^^^^^^
  File "/home/pi/klipper/klippy/extras/tool.py", line 18, in __init__
    self.main_toolchanger = self.printer.load_object(config, 'toolchanger')
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/klipper/klippy/klippy.py", line 130, in load_object
    self.objects[section] = init_func(config.getsection(section))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/klipper/klippy/extras/toolchanger.py", line 383, in load_config
    return result
           ^^^^^^^
  File "/home/pi/klipper/klippy/extras/toolchanger.py", line 26, in __init__
    #        self.gcode_move = self.printer.lookup_object('gcode_move')
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/klipper/klippy/klippy.py", line 97, in lookup_object
    raise self.config_error("Unknown config object '%s'" % (name,))
configparser.Error: Unknown config object 'gcode_move'
```

This change initializes `self.gcode_move` in a consistent manner with other modules that use it (probe.py, gcode_arcs.py, and some other modules from this repo like tool_probe.py and tools_calibrate.py) and removes the error for me.