### PR TITLE
Add an unretract property to tools

### DIFF
--- a/klipper/extras/tool.py
+++ b/klipper/extras/tool.py
@@ -27,6 +27,8 @@ class Tool:
             config, 'gcode_y_offset', None)
         self.gcode_z_offset = self._config_getfloat(
             config, 'gcode_z_offset', None)
+        self.unretract = self._config_getfloat(
+            config, 'unretract', None)
         self.params = {**self.toolchanger.params, **toolchanger.get_params_dict(config)}
         self.original_params = {}
         self.extruder_name = self._config_get(config, 'extruder', None)
@@ -69,6 +71,7 @@ class Tool:
                 'gcode_x_offset': self.gcode_x_offset if self.gcode_x_offset else 0.0,
                 'gcode_y_offset': self.gcode_y_offset if self.gcode_y_offset else 0.0,
                 'gcode_z_offset': self.gcode_z_offset if self.gcode_z_offset else 0.0,
+                'unretract': self.unretract if self.unretract else 0.0,
                 }
 
     def get_offset(self):
@@ -111,6 +114,10 @@ class Tool:
             gcode.run_script_from_command(
                 "ACTIVATE_EXTRUDER EXTRUDER='%s'" % (self.extruder_name,))
         hotend_extruder = toolhead.get_extruder().name
+        heaters = self.printer.lookup_object('heaters')
+        if self.unretract and toolhead.get_extruder().get_heater().can_extrude:
+            gcode.run_script_from_command(
+                "G1 E%f" % (self.unretract, ))
         if self.extruder_stepper and hotend_extruder:
                 gcode.run_script_from_command(
                     "SYNC_EXTRUDER_MOTION EXTRUDER='%s' MOTION_QUEUE=" % (hotend_extruder, ))

--- a/toolchanger.md
+++ b/toolchanger.md
@@ -114,6 +114,11 @@ All gcode macros below have the following context available:
   # The XYZ gcode offset of the toolhead. If set, overrides offset defined 
   # by the parent. If set, even to 0, indicates the offset on that axis is 
   # relevant for this tool and any adjustments will be attributed to this tool.  
+# unretraction: 0.0
+  # Distance in mm to extrude after changing the active extruder. This extrude happens
+  # before any toolhead movement during the tool pickup, so it can be used in combination
+  # with a nozzle wiper mounted in the pickup path. Recommended to be used with a
+  # retraction in the toolhead dropoff_gcode
 # params_*: 
   # Extra params to pass to pickup/dropoff gcode. Accessible in the gcode via
   # `tool.params_name`.
@@ -221,6 +226,7 @@ The following information is available in the `tool` object:
  - `gcode_x_offset`: current X offset.
  - `gcode_y_offset`: current Y offset.
  - `gcode_z_offset`: current Z offset.
+ - `unretract`: current distance in mm to extrude when changing active extruder 
 
 ## toolchanger
 


### PR DESCRIPTION
- `unretract` will set the distance in mm to extrude after changing the active extruder but before performing any of the pickup moves
- per-tool specification allows tuning different extruders to move filament just enough that it is ready to be extruded without oozing
- recommended to be used with a retraction in the toolchanger dropoff_gcode before moving to the docking position

I wanted a way to retract before parking but then to extruder after the active extruder was changed but *before* any of the pickup moves were performed. This allows me to have a nozzle wiper in the pickup path to knock any loose filament off the nozzle before continuing travel to the print.

This tunable method allows me to be ready to extrude on the wipe tower but without a large blob forming from over-extrusion that eventually knocks the wipe tower over.