### PR TITLE
Allow tool offsets to be exported to Gcode macro variables for IDEX use

### DIFF
--- a/examples/calibrate-offsets-idex.cfg
+++ b/examples/calibrate-offsets-idex.cfg
@@ -1,0 +1,58 @@
+[duplicate_pin_override]
+pins: NOZZLE_PROBE
+
+# Allows monitoring the state of the probe pin from Mainail UI
+[filament_switch_sensor tool_probe]
+switch_pin: NOZZLE_PROBE
+pause_on_runout: false
+
+[tools_calibrate]
+pin: NOZZLE_PROBE
+idex_offsets_macro: DC_VARS
+travel_speed: 10
+spread: 5
+lift_z: 2
+lower_z: 0.5
+speed: 5
+lift_speed: 10
+final_lift_z: 10
+sample_retract_dist: 1
+samples_tolerance: 0.05
+samples: 1
+samples_result: median # median, average
+# Settings for nozzle probe calibration - optional.
+#probe: probe # name of the nozzle probe to use; comment out if using Nudge as Z probe
+trigger_to_bottom_z: 0.5  # Was 0.25 # Offset from probe trigger to vertical motion bottoms out.
+# decrease if the nozzle is too high, increase if too low.
+
+[gcode_macro _CALIBRATE_MOVE_OVER_PROBE]
+gcode:
+    BED_MESH_CLEAR
+    G0 Z15 F600
+    # Probe location for VORON Phoenix
+    # Tune this for your machine
+    G0 X305.5 Y604.3 F18000
+    G0 Z7 F600
+    M400
+
+[gcode_macro CALIBRATE_OFFSETS]
+gcode:
+    # Toolhead 0
+    # Heat up the nozzles to improve results
+    SET_HEATER_TEMPERATURE HEATER=extruder TARGET=150
+    SET_HEATER_TEMPERATURE HEATER=extruder1 TARGET=150
+    T0
+    TEMPERATURE_WAIT SENSOR=extruder MINIMUM=150
+    _CALIBRATE_MOVE_OVER_PROBE    
+    TOOL_LOCATE_SENSOR
+    
+    # Toolhead 1
+    T1
+    TEMPERATURE_WAIT SENSOR=extruder1 MINIMUM=150
+    _CALIBRATE_MOVE_OVER_PROBE
+    TOOL_CALIBRATE_TOOL_OFFSET
+
+    # Finish up
+    # Note we're not killing the heaters as we're presumably
+    # about to start a print
+    T0

--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -33,6 +33,7 @@ class ToolsCalibrate:
         self.spread = config.getfloat('spread', 5.0)
         self.lower_z = config.getfloat('lower_z', 0.5)
         self.lift_z = config.getfloat('lift_z', 1.0)
+        self.var_macro = config.get('idex_vars_macro',None)
         self.trigger_to_bottom_z = config.getfloat('trigger_to_bottom_z',
                                                    default=0.0)
         self.lift_speed = config.getfloat('lift_speed',
@@ -124,6 +125,11 @@ class ToolsCalibrate:
         location = self.locate_sensor(gcmd)
         self.last_result = [location[i] - self.sensor_location[i] for i in
                             range(3)]
+        if self.var_macro is not None:
+            vars_macro = self.printer.lookup_object(f"gcode_macro {self.var_macro}")
+            vars_macro.offset_x = self.last_result[0]
+            vars_macro.offset_y = self.last_result[1]
+            vars_macro.offset_z = self.last_result[2]
         self.gcode.respond_info("Tool offset is %.6f,%.6f,%.6f"
                                 % (self.last_result[0], self.last_result[1],
                                    self.last_result[2]))

--- a/tools_calibrate.md
+++ b/tools_calibrate.md
@@ -12,15 +12,16 @@ See the [example](/examples/calibrate-offsets.cfg) folder for a full example.
 ```
 [tools_calibrate]
 pin: ^!PF5
-travel_speed: 20  # mms to travel sideways for XY probing
-spread: 7  # mms to travel down from top for XY probing
-lower_z: 1.0  # The speed (in mm/sec) to move tools down onto the probe
-speed: 2  # The speed (in mm/sec) to retract between probes
-lift_speed: 4  # Z Lift after probing done, should be greater than any Z variance between tools
-final_lift_z: 6 
-sample_retract_dist:2
-samples_tolerance:0.05
-samples:5
+travel_speed: 20  # Speed (in mm/sec) when positioning for XY probing
+spread: 5  # mms to travel sideways when positioning for XY probes
+lower_z: 1.0  # mms to lower nozzle down when positioning for XY probes
+lift_z: 1.0 # mms to lift nozzle up when positioning for XY probes
+speed: 2  # Probe speed
+lift_speed: 4 # Speed (in mm/sec) for all Z moves when probing
+final_lift_z: 6 # Z Lift after probing done, should be greater than any Z variance between tools
+sample_retract_dist: 2
+samples_tolerance: 0.05
+samples: 5
 samples_result: median # median, average
 
 # Settings for nozzle probe calibration - optional.
@@ -28,6 +29,10 @@ probe: probe # name of the nozzle probe to use
 
 trigger_to_bottom_z: 0.25 # Offset from probe trigger to vertical motion bottoms out. 
 # decrease if the nozzle is too high, increase if too low.
+
+idex_vars_macro: DC_VARS # Default not set. Allows exporting of offsets to gcode macro vars
+# Assumes the offsets are named "offset_x", etc. This allows IDEX setups to use the calibration
+# as a standalone component
 ```
 
 ### Clean your nozzles 


### PR DESCRIPTION
Due to the nature of most IDEX setups in Klipper, the toolhead offsets are governed by Gcode macros. In the case of VORON Tridex and VORON Phoenix, this macro is called DC_VARS. 

This allows idex setups like these to use the tool offsets generated by the tools_calibrate natively without hacking string output of calibration command.

Took this opportunity to update the tools_calibrate docs to reflect reality, and added a sample config for IDEX setup (Phoenix in this case)