### PR TITLE
Add ability to quick toggle configs and bug fix

### DIFF
--- a/config_switch.md
+++ b/config_switch.md
@@ -1,0 +1,54 @@
+# Config Switch
+
+This extension provide the means to quickly convert the config from a tool-changer to a traditional single tool-head printer.
+
+## Added Console Command
+
+| Command              | Description                                |
+| -------------------- | ------------------------------------------ |
+| `SAVE_CONFIG_MODE`   | Save session variables in **printer.cfg**. |
+| `TOGGLE_CONFIG_MODE` | Detect and toggle current session config.  |
+
+## Details
+
+#### SAVE_CONFIG_MODE
+
+1. The recording point is marked with `#;<` and can be closed with `#;>`.
+
+2. The command relies on a macro variable, `variable_dock:`, in **printer.cfg** to determine where to save the config to. Therefore, it requires the following macro in **printer.cfg**, among the session variables:
+   
+   ```
+   [gcode_macro _home]
+   variable_xh: 175.0
+   variable_yh: 235.0
+   variable_zh: 10.0
+   variable_dock: True
+   gcode:
+       RESPOND TYPE=echo MSG='Print area centre: {xh}, {yh}, {zh}'
+       RESPOND TYPE=echo MSG='Number of TH: {no_of_toolhead}'
+   ```
+   
+   This variable `variable_dock:` can be either `True` for `False`.
+
+3. The session variables will be safe to `config/config_wt_dock.cfg` or `config/config_no_dock.cfg`
+
+4. It is recommended that you put all of your session variables at the bottom of **printer.cfg**, just before the section for `SAVE_CONFIG`.
+
+#### TOGGLE_CONFIG_MODE
+
+1. Toggle the session variables between that are saved in `config/config_wt_dock.cfg` and `config/config_no_dock.cfg`, if they are available.
+
+2. If either `config/config_wt_dock.cfg` and `config/config_no_dock.cfg` are not yet available. Please build that config (in **printer.cfg**), with the right `variable_dock:` value,  then use `SAVE_CONFIG_MODE` to create the save file.
+
+3. The command needs to be follow up with `FIRMWARE_RESTART` it implement the new settings. It is suggested that you have the following macro in your config:
+   
+   ```
+   [gcode_macro PRINTER_CONFIG_TOGGLE]
+   gcode:
+       M400
+       SAVE_CONFIG_MODE
+       M400
+       TOGGLE_CONFIG_MODE
+       M400
+       FIRMWARE_RESTART
+   ```

--- a/klipper/extras/config_switch.py
+++ b/klipper/extras/config_switch.py
@@ -1,0 +1,134 @@
+import os
+import logging
+
+class ConfigSwitch:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+        ## Register Commands
+        self.gcode.register_command('SAVE_CONFIG_MODE',
+                                    self.cmd_SAVE_CONFIG_MODE,
+                                    desc=self.cmd_SAVE_CONFIG_MODE_help)
+        self.gcode.register_command('TOGGLE_CONFIG_MODE',
+                                    self.cmd_TOGGLE_CONFIG_MODE,
+                                    desc=self.cmd_TOGGLE_CONFIG_MODE_help)
+
+
+    cmd_SAVE_CONFIG_MODE_help = "Save session variables, marked in printer.cfg"
+    def cmd_SAVE_CONFIG_MODE(self, gcmd):
+        ## Variables
+        home_dir = os.path.expanduser("~")
+        destination = ""
+        record = False
+
+        printer_config = os.path.join(home_dir, "printer_data/config/printer.cfg")
+        config_dir = os.path.join(home_dir, "printer_data/config/config")
+        config_wt_dock = os.path.join(config_dir, "config_wt_dock.cfg")
+        config_no_dock = os.path.join(config_dir, "config_no_dock.cfg")
+
+        ## Make the config folder, if it is not already there
+        if not os.path.exists(config_dir):
+            os.makedirs(config_dir, exist_ok=True)
+        
+        ## Decide where it should be saved
+        with open(printer_config) as file:
+            for line in file:
+                ## Set destination file
+                if "variable_dock:" in line.strip():
+                    if "True" in line.strip():
+                        destination = config_wt_dock
+                    elif "False" in line.strip():
+                        destination = config_no_dock
+                    else:
+                        raise gcmd.error("[variable_dock: ] must be 'True' or 'False'")
+        
+        ## Save session variables
+        with open(printer_config) as file:
+            if destination != "":
+                with open(destination, 'w'):
+                    pass
+                for line in file:
+                    ## Record point begin / end
+                    if "#;<" in line.strip():
+                        record = True
+                    if "#;>" in line.strip():
+                        record = False
+                    
+                    ## Start / Stop record
+                    if record is True:
+                        with open(destination, 'a') as savefile:
+                            savefile.write(line)
+                
+                if "config_wt_dock" in destination:
+                    self.gcode.respond_info("Session variables saved to config/config_wt_dock.cfg")
+                elif "config_no_dock" in destination:
+                    self.gcode.respond_info("Session variables saved to config/config_no_dock.cfg")
+
+
+    cmd_TOGGLE_CONFIG_MODE_help = "Toggle saved session variable in printer.cfg"
+    def cmd_TOGGLE_CONFIG_MODE(self, gcmd):
+        ## Variables
+        home_dir = os.path.expanduser("~")
+        source = ""
+        record = True
+
+        printer_config = os.path.join(home_dir, "printer_data/config/printer.cfg")
+        config_dir = os.path.join(home_dir, "printer_data/config/config")
+        config_wt_dock = os.path.join(config_dir, "config_wt_dock.cfg")
+        config_no_dock = os.path.join(config_dir, "config_no_dock.cfg")
+        config_temp = os.path.join(config_dir, "printer.temp")
+
+        ## Detect and toggle current config
+        with open(printer_config) as file:
+            for line in file:
+                if "variable_dock:" in line.strip():
+                    if "True" in line.strip():
+                        source = config_no_dock
+                    elif "False" in line.strip():
+                        source = config_wt_dock
+                    else:
+                        raise gcmd.error("[variable_dock: ] must be 'True' or 'False'")
+        
+        ## Compile new printer.cfg in printer.temp
+        if source != "":
+            if os.path.exists(source):
+                self.gcode.respond_info("Toggle current session variables to:\n" + source)
+                with open(source, 'r') as session_variable_source:
+                    source_content = session_variable_source.read()
+
+                with open(printer_config) as file:
+                    self.gcode.respond_info("Compiling config/printer.temp ...")
+                    with open(config_temp, 'w'):
+                                pass
+                    
+                    for line in file:
+                        ## Record point begin / end
+                        if "#;<" in line.strip():
+                            record = False
+                        if "#;>" in line.strip():
+                            record = True
+
+                        ## Start / Stop record
+                        if record is True:
+                            with open(config_temp, 'a') as tempfile:
+                                tempfile.write(line)
+                    
+                with open(config_temp, 'a') as tempfile:
+                    tempfile.write(source_content)
+
+                with open(config_temp, 'r') as tempfile:
+                    temp_config = tempfile.read()
+                
+                with open(printer_config, 'w') as configfile:
+                    self.gcode.respond_info("Update printer.cfg ...")
+                    configfile.write(temp_config)
+                
+                if os.path.exists(config_temp):
+                    self.gcode.respond_info("Remove config/printer.temp ...")
+                    os.remove(config_temp)
+            else:
+                raise gcmd.error("Missing file:\n" + source)
+
+
+def load_config(config):
+    return ConfigSwitch(config)

--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -191,6 +191,7 @@ class ToolsCalibrate:
         endstop_states = [probe.query_endstop(print_time) for probe in self.probe_multi_axis.mcu_probe] # Check the state of each axis probe (x, y, z)
         self.calibration_probe_inactive = any(endstop_states)
         gcmd.respond_info("Calibration Probe: %s" % (["open", "TRIGGERED"][any(endstop_states)]))
+        return self.calibration_probe_inactive
 
 class PrinterProbeMultiAxis:
     def __init__(self, config, mcu_probe_x, mcu_probe_y, mcu_probe_z):
@@ -377,7 +378,6 @@ class ProbeEndstopWrapper:
 
     def get_position_endstop(self):
         return 0.
-
 
 def load_config(config):
     return ToolsCalibrate(config)


### PR DESCRIPTION
This commit add the ability to toggle variables in printer.cfg between `config_wt_dock` and `config_no_dock`.
And it also fix a bug where the indicating variable for the calibration probe lag behind reality, and required to be query twice.