### PR TITLE
Move liftbar up after homing

### DIFF
--- a/examples/per tool probe+liftbar+flying gantry/liftbar.cfg
+++ b/examples/per tool probe+liftbar+flying gantry/liftbar.cfg
@@ -45,6 +45,7 @@ hold_current: 0.5
 gcode:
  {% if not printer['manual_rail liftbar'].enabled %}
     MANUAL_RAIL RAIL=liftbar HOME=1
+    LIFTBAR_MOVE Z={printer.toolchanger.params_liftbar_min_z + printer.toolchanger.params_liftbar_stow_height}
  {% endif %}
 
 [gcode_macro LIFTBAR_MOVE]


### PR DESCRIPTION
In 2.4 (flying gantry), move liftbar up after homing to avoid crashing on it if moving toolhead to front of the printer.