### PR TITLE
Updated tools calibrate docs

### DIFF
--- a/tools_calibrate.md
+++ b/tools_calibrate.md
@@ -59,7 +59,7 @@ samples_tolerance:    (mm)
      a good probe will work with 0.05, altho increasing it has no effect on results.
      more a "sanity check" then anything else.
 
-samples_retries: 
+samples_tolerance_retries: 
      the amount of times to retry the probing when the sample tolerance has been exceeded.
 
 samples_result:       ['median' | 'average']

--- a/tools_calibrate.md
+++ b/tools_calibrate.md
@@ -15,7 +15,7 @@ pin: GPIO pin (e.g., '^PG11')
      The pin Klipper will monitor to detect a probe trigger.
      - depending on probe may require inversion (ie: !PG11)
      - normally closed: nudge (no inversion)
-     - normally open: sexball [microswitch type] (no inversion)
+     - normally open: sexball [microswitch type] (inversion)
 
 spread:               (mm)
     X/Y distance from center for probing sequence


### PR DESCRIPTION
Updated tools calibrate docs.

some things are described in confusing ways. ie:
lower_z: 1.0 # The speed (in mm/sec) to move tools down onto the probe
(is not the speed, its a distance)

lift_speed: 4 # Z Lift after probing done, should be greater than any Z variance between tools
is actually a speed.

spread: 7 # mms to travel down from top for XY probing
is not the spread. thats the lower_z.