### PR TITLE
tool detection extremely confusing.

### DIFF
--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -495,7 +495,7 @@ class Toolchanger:
         self._ensure_toolchanger_ready(gcmd)
         expected = self.gcmd_tool(gcmd, self.active_tool)
         if not self.has_detection:
-            return
+            raise gcmd.error("VERIFY_TOOL_DETECTED needs tool detection to be set up.")
         toolhead = self.printer.lookup_object('toolhead')
         reactor = self.printer.get_reactor()
         if gcmd.get_int("ASYNC", 0) == 1:


### PR DESCRIPTION
[VERIFY_TOOL_DETECTED](https://github.com/viesturz/klipper-toolchanger/blob/98b67090b89ce24e659580239a2472cb0a4b5a83/klipper/extras/toolchanger.py#L497C1-L497C9) silently exits making users think "we good" if they confused tool detection with tool probe detection.
