### PR TITLE
no bed mesh = internal error on init.

### DIFF
--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -534,7 +534,7 @@ class Toolchanger:
         if tool.gcode_z_offset is not None:
             cmd += ' Z=%f' % (tool.gcode_z_offset + extra_z_offset,)
         self.gcode.run_script_from_command(cmd)
-        mesh = self.printer.lookup_object('bed_mesh')
+        mesh = self.printer.lookup_object('bed_mesh', default=None)
         if mesh and mesh.get_mesh():
             self.gcode.run_script_from_command(
                 'BED_MESH_OFFSET X=%.6f Y=%.6f ZFADE=%.6f' %


### PR DESCRIPTION
  File "/home/contomo/klipper/klippy/extras/toolchanger.py", line 537, in _set_tool_gcode_offset
    mesh = self.printer.lookup_object('bed_mesh')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/contomo/klipper/klippy/klippy.py", line 79, in lookup_object
    raise self.config_error("Unknown config object '%s'" % (name,))
configparser.Error: Unknown config object 'bed_mesh'