### PR TITLE
Bed mesh zfade flipped

### DIFF
--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -539,7 +539,7 @@ class Toolchanger:
             self.gcode.run_script_from_command(
                 'BED_MESH_OFFSET X=%.6f Y=%.6f ZFADE=%.6f' %
                 (-tool.gcode_x_offset, -tool.gcode_y_offset,
-                 -tool.gcode_z_offset))
+                 tool.gcode_z_offset))
 
     def _position_to_xyz(self, position, axis):
         result = {}


### PR DESCRIPTION
i am tbh a bit confused on the handling of the whole bed mesh. why do we need mesh offsets anyways?
the mesh only "sees" gcode pos anyways. and our offsets are adjusted in a way so that gcode pos == real world pos

so why do we need to tell the bed mesh any offsets? nozzle location in XY never changed, right (gcode speaking)? its called BED_MESH after all and not GANTRY_MESH or something like that.