### PR TITLE
PROBE_CALIBRATE saving under wrong name

### DIFF
--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -78,9 +78,11 @@ class ToolProbeEndstop:
         if self.active_probe:
             self.mcu_probe.set_active_mcu(tool_probe.mcu_probe)
             self.active_tool_number = self.active_probe.tool
+            self.cmd_helper.name = self.active_probe.name
         else:
             self.mcu_probe.set_active_mcu(None)
             self.active_tool_number = -1
+            self.cmd_helper.name = self.name
 
     def _query_open_tools(self):
         print_time = self.toolhead.get_last_move_time()


### PR DESCRIPTION
the name for the command helper is currently coming from [`self.name = config.get_name()`](https://github.com/viesturz/klipper-toolchanger/blob/b876edacd161c363460e2c6545afbc668553a405/klipper/extras/tool_probe_endstop.py#L15) This is also how it is added to save_config ([`self.cmd_helper = probe.ProbeCommandHelper(config, self, self.mcu_probe.query_endstop)`](https://github.com/viesturz/klipper-toolchanger/blob/b876edacd161c363460e2c6545afbc668553a405/klipper/extras/tool_probe_endstop.py#L27))

I am honestly unsure wether this is the right way to do it.
it definetly works, Im not sure if there is any point in time where wed like to save under the original name?
(i have not tested this for edge cases yet, ie named `[tool_probe_endstop]` sections or unnamed `[tool_probe]`  sections.

