### PR TITLE
Update tool_probe_endstop.py to put out the offsets for x and y allso

### DIFF
--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -138,9 +138,13 @@ class ToolProbeEndstop:
         status['active_tool_number'] = self.active_tool_number
         if self.active_probe:
             status['active_tool_probe'] = self.active_probe.name
+            status['active_tool_probe_x_offset'] = self.active_probe.get_offsets()[0]
+            status['active_tool_probe_y_offset'] = self.active_probe.get_offsets()[1]
             status['active_tool_probe_z_offset'] = self.active_probe.get_offsets()[2]
         else:
             status['active_tool_probe'] = None
+            status['active_tool_probe_x_offset'] = 0.0
+            status['active_tool_probe_y_offset'] = 0.0
             status['active_tool_probe_z_offset'] = 0.0
         return status
 


### PR DESCRIPTION
Because, maybe, there are toolchangers that use other z probes that are not the nozzle, x and y offsets are needet for the probe offset on x and y axis. :)