### PR TITLE
issue description fix.

### DIFF
--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -99,7 +99,7 @@ class ToolProbeEndstop:
         elif len(candidates) == 0:
             return "All probes triggered"
         else:
-            return  "Multiple probes not triggered: %s" % map(lambda p: p.name, candidates)
+            return f"Multiple probes not triggered: {[p.name for p in candidates]}"
 
     def _ensure_active_tool_or_fail(self, gcode):
         if self.active_probe:


### PR DESCRIPTION
map is lazy iterator never describes issue confusing output. `Multiple probes not triggered: `
->
`Multiple probes not triggered: ['tool_probe T0', 'tool_probe T1', 'tool_probe T2', 'tool_probe T3']`