### PR TITLE
UNSELECT_TOOL fix, Go to Safe Y before going down

### DIFF
--- a/examples/dock location/fixed/toolchanger.cfg
+++ b/examples/dock location/fixed/toolchanger.cfg
@@ -61,6 +61,11 @@
       {% set speed = tool.params_path_speed|float * (pos.get('f', 1.0)|float) %}
       G0 {% if 'x' in pos %}X{x + pos['x']|float}{% endif %} {% if 'y' in pos %}Y{y + pos['y']|float}{% endif %} {% if 'z' in pos %}Z{z + pos['z']|float }{% endif %} F{speed}
     {% endfor %}
+    ## Return to safe Y if no pickup_tool
+    {% if pickup_tool is none %}
+      G0 Y{tool.params_safe_y} F{fast}
+    {% endif %}
+    
 
   pickup_gcode:
     {% set x = tool.params_park_x|float %}


### PR DESCRIPTION
This had to be added, so shuttle does not simply restore Z when it still interfere with bottom pin of StealthChanger backplate.