### PR TITLE
Avoid crashing a toolless shuttle into the dock when picking up a tool

### DIFF
--- a/examples/dock location/fixed/toolchanger.cfg
+++ b/examples/dock location/fixed/toolchanger.cfg
@@ -76,7 +76,12 @@
     RESPOND TYPE=echo MSG='Picking up {tool.name}'
     G90
     #   ##############  Fast to the last point  ##############
-    ROUNDED_G0 Y={tool.params_close_y} F={fast} D=5
+    {% if dropoff_tool is none and pickup_tool is not none %}
+      ROUNDED_G0 Y={tool.params_safe_y} D=20 F={fast}
+    {% else %}
+      ROUNDED_G0 Y={tool.params_close_y} F={fast} D=5
+    {% endif %}
+    
     ROUNDED_G0 X={x} Z={z + path[0]['z']|float} F={fast} D=5
     ROUNDED_G0 Y={y + path[0]['y']|float} F={fast} D=0
     # Wait for temp before actually picking up the tool, while the nozzle is resting on it's pad.


### PR DESCRIPTION
When there is no tool on the shuttle, make sure to travel to safe Y instead of close Y when doing a pickup to avoid crashing into the docks when it's at the front of the printer below the docks.