### PR TITLE
fix creeping Z offset when unselecting and selecting tool

### DIFF
--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -358,7 +358,8 @@ class Toolchanger:
             # Restore state sets old gcode offsets, fix that.
             if tool is not None:
                 self._set_tool_gcode_offset(tool, extra_z_offset)
-
+            else: # Unselect: remove tool offset but global z
+                self.gcode.run_script_from_command(f"SET_GCODE_OFFSET X=0.0 Y=0.0 Z={extra_z_offset:.6f}")
             self.status = STATUS_READY
             if tool:
                 gcmd.respond_info(


### PR DESCRIPTION
fixed an issue where z offset multiplied when selecting and unselecting tools repeatedly because of a missing reset/carryover of global z offset (extra_z_offset)

tldr:

- `UNSELECT_TOOL` (with T1 mounted)
```py
extra_z_offset = current_z_offset - (self.active_tool.gcode_z_offset if self.active_tool else 0.0)
# 0
self.gcode.run_script_from_command("SAVE_GCODE_STATE NAME=_toolchange_state")
# saves T1 offsets
self.gcode.run_script_from_command("SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0")
# does it shenanigans
self.gcode.run_script_from_command("RESTORE_GCODE_STATE NAME=_toolchange_state MOVE=0")
# restores T1 offsets
if tool is not None:
        self._set_tool_gcode_offset(tool, extra_z_offset)
# tool == None so this is skipped.
```
- `SELECT_TOOL` (following this with no tool mounted)
```py
extra_z_offset = current_z_offset - (self.active_tool.gcode_z_offset if self.active_tool else 0.0)
# T1 offsets = (cause  T1 offsets - (... no tool -> ) else 0.0 )
......
if tool is not None:
        self._set_tool_gcode_offset(tool, extra_z_offset)
# now load 2x T1 Z offset (T1 + extra which is also T1)
```

I hope this makes sense.
