### PR TITLE
Fix restore_position to account for extra Z offset

### DIFF
--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -414,7 +414,8 @@ class Toolchanger:
             'restore_position': self.last_change_restore_position,
         }
         self.run_gcode('recover_gcode', tool.recover_gcode, extra_context)
-        self._restore_axis(self.last_change_gcode_position, self.last_change_restore_axis, tool)
+        self._restore_axis(self.last_change_gcode_position, self.last_change_restore_axis,
+            tool, self.last_change_extra_z_offset)
         self.gcode.run_script_from_command(
             "RESTORE_GCODE_STATE NAME=_toolchange_state MOVE=0")
         # Restore state sets old gcode offsets, fix that.


### PR DESCRIPTION
Fixes issues #48 and #69

###  Steps to reproduce 
Run the following G-Code

```
SET_GCODE_OFFSET Z=1 X=0 Y=0
G0 X100 Y200 Z10
SELECT_TOOL T=0 RESTORE_AXIS=XYZ
SELECT_TOOL T=1 RESTORE_AXIS=XYZ
SELECT_TOOL T=0 RESTORE_AXIS=XYZ
```

### Expeced result

Toolhead returns to a GCode position set before tool changes (100,200,10)

### Actual result

Toolhead "sinks" by 1mm on every tool change