### PR TITLE
Adjust EPSILON and refine G0p method behavior

### DIFF
--- a/klipper/extras/rounded_path.py
+++ b/klipper/extras/rounded_path.py
@@ -14,7 +14,7 @@ from math import comb
 
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math
-EPSILON = 0.001
+EPSILON = 1e-9
 EPSILON_ANGLE = 0.001
 
 class ControlPoint:
@@ -241,6 +241,9 @@ class RoundedPath:
         self._g0p(p, p.vec)
 
     def _g0p(self, p: ControlPoint, vec: list):
+        # ignore extremely short residual misalignements that may collapse lookahead junction velocity on otherwise smooth paths.
+        if self.lastg0 and _vdist(self.lastg0, vec) <= 0.001:
+            return
         self.G0_params["X"]=vec[0]
         self.G0_params["Y"]=vec[1]
         self.G0_params["Z"]=vec[2]


### PR DESCRIPTION
Happens sometimes.

Bias from `_deconflict_lin_d` plus a few duplicate/near duplicate points can introduce tiny sharp corners at junctions. That can make the lookahead junction velocity collapse (sometimes all the way down to square_corner_velocity).

Reducing `EPSILON`, specifically inside `_deconflict_lin_d`, reduces that bias, but doesn’t eliminate the issue completely and or reliably.

Workaround:   
lowering `EPSILON` and discard moves shorter than `0.001`. Seems reasonable to me and avoids those slowdowns.  
Interrested to heat your opinion in this matter too, maybe you have a better idea on how to solve/approach this.

---

As a comparison:

### Tiny misalignments causing lookahead junction velocity collapse
<img width="400" height="300" alt="motion_plot_2026-02-16_20-32-40" src="https://github.com/user-attachments/assets/2cce6676-ed73-49c6-a7cd-cf978f1404d1" />

### Removing tiny misalignments
<img width="400" height="300" alt="motion_plot_2026-02-16_20-39-22" src="https://github.com/user-attachments/assets/895f0e46-9cdb-4664-b541-b68847bfebfe" />

> Oh, tiny note, this happends primarly when arcs from different directions join, ie X → Z, Z → Y