### PR TITLE
CPAP Air Diverter Min/Max Angle Control

### DIFF
--- a/klipper/extras/tool.py
+++ b/klipper/extras/tool.py
@@ -56,7 +56,11 @@ class Tool:
         self.t_command_restore_axis = self._config_get(
             config, 't_command_restore_axis', 'XYZ')
         self.tool_number = config.getint('tool_number', -1, minval=0)
-
+        self.diverter_min_angle = self._config_getfloat(
+            config, 'diverter_min_angle', 0.0)
+        self.diverter_max_angle = self._config_getfloat(
+            config, 'diverter_max_angle', 100.0)
+        
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("ASSIGN_TOOL", "TOOL", self.name,
                                    self.cmd_ASSIGN_TOOL,

--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -787,6 +787,11 @@ class FanSwitcher:
         self.pending_speed = None
         self.active_fan = None
         self.transfer_fan_speed = toolchanger.transfer_fan_speed
+        
+        # CPAP Air Diverter Servo
+        self.has_air_diverter = config.has_section('servo air_diverter')
+        self.air_diverter_name = 'air_diverter'
+        
         if self.has_printer_fan:
             raise config.error("Cannot use tool fans together with [fan], use [fan_generic] for tool fans.")
         if not self.has_multi_fan and not self.has_printer_fan:
@@ -811,6 +816,7 @@ class FanSwitcher:
                 self.pending_speed = None
                 self.gcode.run_script_from_command(
                     "SET_FAN_SPEED FAN='%s' SPEED=%s" % (self.active_fan.fan_name, speed_to_set))
+                self.set_air_diverter(speed_to_set, self.toolchanger.active_tool)
             else:
                 self.pending_speed = speed_to_set
 
@@ -826,8 +832,28 @@ class FanSwitcher:
     def set_speed(self, speed, tool):
         if tool and tool.fan:
             self.gcode.run_script_from_command("SET_FAN_SPEED FAN='%s' SPEED=%s" % (tool.fan.fan_name, speed))
+            self.set_air_diverter(speed, tool)
         else:
             self.pending_speed = speed
+            self.set_air_diverter(speed, tool)
+    
+    # CPAP Air diverter helpers
+    def get_diverter_angles(self, tool):
+        if not tool:
+            return 0.0, 100.0
+        min_angle = float(getattr(tool, 'diverter_min_angle', 0.0))
+        max_angle = float(getattr(tool, 'diverter_max_angle', 100.0))
+        return min_angle, max_angle
+
+    def set_air_diverter(self, speed, tool=None):
+        if not self.has_air_diverter:
+            return
+        # Clamp speed
+        speed = max(0.0, min(1.0, speed))
+        min_angle, max_angle = self.get_diverter_angles(tool)
+        # Automatically inverts if min_angle > max_angle
+        angle = min_angle + speed * (max_angle - min_angle)
+        self.gcode.run_script_from_command("SET_SERVO SERVO=%s ANGLE=%.1f" % (self.air_diverter_name, angle))
 
 # Helper class for applying tool offset
 class ToolGcodeTransform:


### PR DESCRIPTION
Code addition providing CPAP air diverter min/max angle control based on fan speed for multiple toolheads. This change does not disable existing toolhead fans. If the max angle is greater than min angle, the rotation of the air diverter reverses. The CPAP fan speed is activated by start gcode and remains constant.

Gcode Example:

printer.cfg

```
[tool T0]
tool_number: 0
extruder: extruder
fan: T0_partfan
diverter_min_angle: 100
diverter_max_angle: 0

[tool T1]
tool_number: 1
extruder: extruder1
fan: T1_partfan
diverter_min_angle: 0
diverter_max_angle: 100
```

cpap.cfg
```
[servo air_diverter] # Servo Angle
pin: CPAP:PB9
maximum_servo_angle: 100
minimum_pulse_width: 0.0005
maximum_pulse_width: 0.0014

[fan_generic cpap] # CPAP Speed
pin: CPAP: PA0
max_power: 0.8
shutdown_speed: 0
cycle_time: 0.010
hardware_pwm: false
kick_start_time: 0.100
off_below: 0.1

[gcode_macro CPAP_START]
gcode:
  SET_FAN_SPEED FAN=cpap SPEED=0.2

[gcode_macro CPAP_STOP]
gcode:
  SET_FAN_SPEED FAN=cpap SPEED=0.0
```