### PR TITLE
Add per-tool filament usage tracking

### DIFF
--- a/klipper/extras/tool.py
+++ b/klipper/extras/tool.py
@@ -12,6 +12,10 @@ class Tool:
         self.printer = config.get_printer()
         self.params = config.get_prefix_options('params_')
         self.gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        self.filament_used = 0.
+        self._last_epos = 0.
+        self._active = False
+        self.gcode_move = self.printer.load_object(config, 'gcode_move')
 
         self.name = config.get_name()
         toolchanger_name = config.get('toolchanger', 'toolchanger')
@@ -65,6 +69,9 @@ class Tool:
         gcode.register_mux_command("ASSIGN_TOOL", "TOOL", self.name,
                                    self.cmd_ASSIGN_TOOL,
                                    desc=self.cmd_ASSIGN_TOOL_help)
+        gcode.register_mux_command("RESET_TOOL_FILAMENT", "TOOL", self.name,
+                                   self.cmd_RESET_TOOL_FILAMENT,
+                                   desc="Reset filament usage counter for tool")
 
         self.printer.register_event_handler("klippy:connect",
                                     self._handle_connect)

--- a/klipper/extras/tool.py
+++ b/klipper/extras/tool.py
@@ -122,6 +122,12 @@ class Tool:
         self.toolchanger.note_detect_change(self, eventtime)
 
     def get_status(self, eventtime):
+        filament = self.filament_used
+        if self._active:
+            gc_status = self.gcode_move.get_status(eventtime)
+            cur_epos = gc_status['position'].e
+            filament += max(0., (cur_epos - self._last_epos)
+                           / gc_status['extrude_factor'])
         return {**self.params,
                 'name': self.name,
                 'toolchanger': self.toolchanger.name,
@@ -135,6 +141,7 @@ class Tool:
                 'gcode_x_offset': self.gcode_x_offset if self.gcode_x_offset else 0.0,
                 'gcode_y_offset': self.gcode_y_offset if self.gcode_y_offset else 0.0,
                 'gcode_z_offset': self.gcode_z_offset if self.gcode_z_offset else 0.0,
+                'filament_used': filament,
                 }
 
     def get_offset(self):
@@ -153,6 +160,14 @@ class Tool:
         self.tool_number = number
         self.main_toolchanger.assign_tool(self, number, prev_number, replace)
         self.register_t_gcode(number)
+
+    def cmd_RESET_TOOL_FILAMENT(self, gcmd):
+        self.filament_used = 0.
+        self._last_epos = 0.
+        if self._active:
+            gc_status = self.gcode_move.get_status()
+            self._last_epos = gc_status['position'].e
+        gcmd.respond_info('%s filament counter reset' % self.name)
 
     def register_t_gcode(self, number):
         gcode = self.printer.lookup_object('gcode')

--- a/klipper/extras/tool.py
+++ b/klipper/extras/tool.py
@@ -184,7 +184,16 @@ class Tool:
                     "SYNC_EXTRUDER_MOTION EXTRUDER='%s' MOTION_QUEUE='%s'" % (self.extruder_stepper_name, hotend_extruder, ))
         if self.fan:
             self.toolchanger.fan_switcher.activate_fan(self.fan)
+        gc_status = self.gcode_move.get_status()
+        self._last_epos = gc_status['position'].e
+        self._active = True
     def deactivate(self):
+        if self._active:
+            gc_status = self.gcode_move.get_status()
+            cur_epos = gc_status['position'].e
+            self.filament_used += max(0., (cur_epos - self._last_epos)
+                                      / gc_status['extrude_factor'])
+            self._active = False
         if self.extruder_stepper:
             toolhead = self.printer.lookup_object('toolhead')
             gcode = self.printer.lookup_object('gcode')

--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -194,6 +194,9 @@ class Toolchanger:
                                     self.cmd_VERIFY_TOOL_DETECTED)
         self.gcode.register_command("ADJUST_Z_AFTER_TOOL_NOZZLE_HOME",
                                     self.cmd_ADJUST_Z_AFTER_TOOL_NOZZLE_HOME)
+        self.gcode.register_command("RESET_ALL_TOOL_FILAMENT",
+                                    self.cmd_RESET_ALL_TOOL_FILAMENT,
+                                    desc="Reset filament counters for all tools")
         self.fan_switcher = None
         self.tool_probe_endstop = None
         self.validate_tool_timer = None
@@ -712,6 +715,15 @@ class Toolchanger:
         if not tool:
             raise gcmd.error("ADJUST_Z_AFTER_TOOL_NOZZLE_HOME - no active tool")
         self._adjust_z_position_for_tool(tool)
+
+    def cmd_RESET_ALL_TOOL_FILAMENT(self, gcmd):
+        for tool in self.tools.values():
+            tool.filament_used = 0.
+            tool._last_epos = 0.
+            if tool._active:
+                gc_status = tool.gcode_move.get_status()
+                tool._last_epos = gc_status['position'].e
+        gcmd.respond_info('All tool filament counters reset')
 
     def _adjust_z_position_for_tool(self, tool):
         z_offset = tool.gcode_z_offset

--- a/toolchanger.md
+++ b/toolchanger.md
@@ -258,6 +258,19 @@ Defaults to current tool if tool not specified.
 Resets a parameter to its original value.
 Defaults to current tool if tool not specified.
 
+### RESET_TOOL_FILAMENT
+`RESET_TOOL_FILAMENT TOOL=<name>`: Reset the filament usage counter for a specific tool.
+
+### RESET_ALL_TOOL_FILAMENT
+`RESET_ALL_TOOL_FILAMENT`: Reset filament usage counters for all tools.
+Add this to your `PRINT_START` macro to track per-print usage:
+```
+[gcode_macro PRINT_START]
+gcode:
+  RESET_ALL_TOOL_FILAMENT
+  # ... rest of your PRINT_START
+```
+
 # Gcodes if *fan* is specified for any of tools
 
 ### M106 
@@ -292,6 +305,7 @@ The following information is available in the `tool` object:
  - `gcode_x_offset`: current X offset.
  - `gcode_y_offset`: current Y offset.
  - `gcode_z_offset`: current Z offset.
+ - `filament_used`: filament extruded by this tool in mm since last reset. Tracks extrusion per tool independently, accounting for extrude_factor. Reset with `RESET_TOOL_FILAMENT` or `RESET_ALL_TOOL_FILAMENT`.
 
 ## toolchanger
 


### PR DESCRIPTION
Tracks filament extrusion per tool using the same approach as Klipper's `print_stats.py`. AFC-Klipper-Add-On does something similar at the lane level for their filament changers — we needed the same thing for toolchangers so each tool knows how much filament it actually used.

`filament_used` (mm) is exposed in each tool's status, so Moonraker can query it:
```
GET /printer/objects/query?tool%20T0&tool%20T1
```

Two new gcode commands:
- `RESET_TOOL_FILAMENT TOOL="tool T0"` — reset one tool
- `RESET_ALL_TOOL_FILAMENT` — reset all (put in PRINT_START)

Changes:
- `tool.py` — tracking state in __init__, e-position snapshot on activate/deactivate, filament_used in get_status, reset command
- `toolchanger.py` — RESET_ALL_TOOL_FILAMENT convenience command to zero all tools at once
- `toolchanger.md` — docs for new commands and status field

Tested on a Trident MaxMax setup with 4 tools. Tested on T2 and T3:
```
T0: 0.0mm
T1: 0.0mm
T2: 760.6mm
T3: 1405.2mm
Sum: 2165.8mm vs print_stats: 2165.7mm
```