### PR TITLE
Delay registration of t gcode macros until after config parsing is done

### DIFF
--- a/klipper/extras/tool.py
+++ b/klipper/extras/tool.py
@@ -109,6 +109,9 @@ class Tool:
         if self.fan_name:
             self.fan = self.printer.lookup_object(self.fan_name,
                       self.printer.lookup_object("fan_generic " + self.fan_name, None))
+        # Register T commands for initial tool assignments after all gcode_macros are loaded
+        if self.tool_number >= 0:
+            self.register_t_gcode(self.tool_number)
 
     def _handle_detect(self, eventtime, is_triggered):
         self.detect_state = toolchanger.DETECT_ABSENT if is_triggered else toolchanger.DETECT_PRESENT
@@ -145,7 +148,10 @@ class Tool:
         prev_number = self.tool_number
         self.tool_number = number
         self.main_toolchanger.assign_tool(self, number, prev_number, replace)
-        self.register_t_gcode(number)
+        # Only register T commands when replacing (runtime reassignment)
+        # Initial assignments are handled in _handle_connect
+        if replace:
+            self.register_t_gcode(number)
 
     def register_t_gcode(self, number):
         gcode = self.printer.lookup_object('gcode')


### PR DESCRIPTION
Commit 1e273ab4 "Fix tool detection not always working at startup" broke config parsing for users that had Tn gcode commands defined in their config files (as per the KTC examples), at least for the case where the macros were being parsed after the tools. KTC was making the gcode macro, and then klipper would try to set up a macro of the same name. This didn't happen before because the KTC macro registration was delayed until after config parsing.

We still want to do the assign_tool work during config parsing to avoid the race with other callbacks. But we don't need to register the macros right away. So this change just pushes the macro registration at startup back into the delay path, so that this always happens after the config is done being parsed.

Fixes #168