### PR TITLE
tools_calibrate: use raw trigger Z for probe offset

### DIFF
--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -158,7 +158,8 @@ class ToolsCalibrate:
         # now move down with the tool probe
         probe_session = probe.start_probe_session(gcmd)
         probe_session.run_probe(gcmd)
-        probe_z = probe_session.pull_probed_results()[0][2]
+        probe_result = probe_session.pull_probed_results()[0]
+        probe_z = probe_result.test_z
         probe_session.end_probe_session()
 
         z_offset = probe_z - nozzle_z + self.trigger_to_bottom_z

--- a/tools_calibrate.md
+++ b/tools_calibrate.md
@@ -98,6 +98,9 @@ All probing moves and final offsets will be printed in the console.
 
 - Run TOOL_CALIBRATE_PROBE_OFFSET - to measure Z offset from nozzle triggering the probe to tool's nozzle probe activating.
 
+The calibration uses the tool probe's raw trigger Z position, so an existing
+configured probe `z_offset` is not applied to the new calibration result.
+
 All probing moves and final offsets will be printed in the console.
 
 


### PR DESCRIPTION
## Summary

TOOL_CALIBRATE_PROBE_OFFSET currently reads index [2] from the probe session result when calculating the new probe z_offset.

With Klipper's current probe session result type, that value is the offset-adjusted bed Z. If a probe z_offset is already configured, it is applied before the calibration math runs, causing repeated calibration to alternate between the real offset and approximately zero.

This changes the calibration to use probe_result.test_z, the raw trigger/toolhead Z position, so the existing configured probe z_offset is not folded into the new result.

## Testing

Tested on a toolchanger setup where repeated TOOL_CALIBRATE_PROBE_OFFSET runs previously alternated between approximately -0.17 and 0.00. After this change, repeated runs remained consistent around the expected value.

Also ran:

- python3 -m py_compile klipper/extras/tools_calibrate.py
- git diff --check origin/main..tools-calibrate-raw-trigger-z