### PR TITLE
tool_probe: update for latest Klipper probe API

### DIFF
--- a/klipper/extras/tool_probe.py
+++ b/klipper/extras/tool_probe.py
@@ -16,9 +16,10 @@ class ToolProbe:
         ppins = self.printer.lookup_object('pins')
         ppins.allow_multi_use_pin(pin.replace('^', '').replace('!', ''))
 
-        self.mcu_probe = probe.ProbeEndstopWrapper(config)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
         self.param_helper = probe.ProbeParameterHelper(config)
+        self.mcu_probe = probe.ProbeEndstopWrapper(
+            config, self.probe_offsets, self.param_helper)
 
         if self.tool_number is not None:
             # Crash detection stuff

--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -3,35 +3,7 @@
 # Copyright (C) 2023 Viesturs Zarins <viesturz@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import pins
 from . import probe
-
-# Latest Klipper only needs the virtual endstop object to register
-# probe:z_virtual_endstop and report its current position_endstop.
-class ToolHomingViaProbeHelper:
-    def __init__(self, config, position_endstop_cb, query_endstop_cb):
-        self.printer = config.get_printer()
-        self.position_endstop_cb = position_endstop_cb
-        self.query_endstop_cb = query_endstop_cb
-        self.printer.lookup_object('pins').register_chip('probe', self)
-
-    def add_stepper(self, stepper):
-        pass
-    def get_steppers(self):
-        return []
-    def query_endstop(self, print_time):
-        return self.query_endstop_cb(print_time)
-    def get_position_endstop(self):
-        return self.position_endstop_cb()
-
-    def setup_pin(self, pin_type, pin_params):
-        if pin_type != 'endstop' or pin_params['pin'] != 'z_virtual_endstop':
-            raise pins.error(
-                "Probe virtual endstop only useful as endstop pin")
-        if pin_params['invert'] or pin_params['pullup']:
-            raise pins.error(
-                "Can not pullup/invert probe virtual endstop")
-        return self
 
 # Virtual endstop, using a tool attached Z probe in a toolchanger setup.
 # Tool endstop change may be done either via SET_ACTIVE_TOOL_PROBE TOOL=99
@@ -54,9 +26,9 @@ class ToolProbeEndstop:
         self.probe_offsets = self.probe
         self.param_helper = self.probe
         self.cmd_helper = probe.ProbeCommandHelper(config, self, self.mcu_probe.query_endstop)
-        self.homing_helper = ToolHomingViaProbeHelper(
-            config, lambda: self.get_offsets()[2],
-            self.mcu_probe.query_endstop)
+        # Current Klipper only uses position_endstop to identify virtual
+        # probe homing. The active probe session supplies the actual offset.
+        probe.HomingViaProbeHelper(config, 0.0, self.mcu_probe.query_endstop)
         self.probe_session = probe.SampleAveragingHelper(
             config, self.param_helper, self.mcu_probe.start_probe_session)
 
@@ -263,13 +235,6 @@ class EndstopRouter:
         if not self.active_mcu:
             raise self.printer.command_error("Cannot query endstop - no active tool probe.")
         return self.active_mcu.query_endstop(print_time)
-    def get_position_endstop(self):
-        if not self.active_mcu:
-            # This will get picked up by the endstop, and is static
-            # Report 0 and fix up in the homing sequence
-            return 0.0
-        return 0.0
-
     def start_probe_session(self, gcmd):
         if not self.active_mcu:
             raise self.printer.command_error("Cannot start probe session - no active tool probe.")

--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -3,7 +3,35 @@
 # Copyright (C) 2023 Viesturs Zarins <viesturz@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import pins
 from . import probe
+
+# Latest Klipper only needs the virtual endstop object to register
+# probe:z_virtual_endstop and report its current position_endstop.
+class ToolHomingViaProbeHelper:
+    def __init__(self, config, position_endstop_cb, query_endstop_cb):
+        self.printer = config.get_printer()
+        self.position_endstop_cb = position_endstop_cb
+        self.query_endstop_cb = query_endstop_cb
+        self.printer.lookup_object('pins').register_chip('probe', self)
+
+    def add_stepper(self, stepper):
+        pass
+    def get_steppers(self):
+        return []
+    def query_endstop(self, print_time):
+        return self.query_endstop_cb(print_time)
+    def get_position_endstop(self):
+        return self.position_endstop_cb()
+
+    def setup_pin(self, pin_type, pin_params):
+        if pin_type != 'endstop' or pin_params['pin'] != 'z_virtual_endstop':
+            raise pins.error(
+                "Probe virtual endstop only useful as endstop pin")
+        if pin_params['invert'] or pin_params['pullup']:
+            raise pins.error(
+                "Can not pullup/invert probe virtual endstop")
+        return self
 
 # Virtual endstop, using a tool attached Z probe in a toolchanger setup.
 # Tool endstop change may be done either via SET_ACTIVE_TOOL_PROBE TOOL=99
@@ -26,10 +54,11 @@ class ToolProbeEndstop:
         self.probe_offsets = self.probe
         self.param_helper = self.probe
         self.cmd_helper = probe.ProbeCommandHelper(config, self, self.mcu_probe.query_endstop)
-        self.homing_helper = probe.HomingViaProbeHelper(
-            config, self.mcu_probe, self.probe_offsets, self.param_helper)
-        self.probe_session = probe.ProbeSessionHelper(
-            config, self.param_helper, self.homing_helper.start_probe_session)
+        self.homing_helper = ToolHomingViaProbeHelper(
+            config, lambda: self.get_offsets()[2],
+            self.mcu_probe.query_endstop)
+        self.probe_session = probe.SampleAveragingHelper(
+            config, self.param_helper, self.mcu_probe.start_probe_session)
 
         # Emulate the probe object, since others rely on this.
         if self.printer.lookup_object('probe', default=None):
@@ -200,14 +229,10 @@ class ProbeRouter:
         if not self.active_probe:
             return  0.0, 0.0, 0.0
         return self.active_probe.probe_offsets.get_offsets(*args, **kwargs)
-    def create_probe_result(self, *args, **kwargs):
-        if not self.active_probe:
-            raise self.printer.command_error("Cannot query endstop - no active tool probe.")
-        return self.active_probe.probe_offsets.create_probe_result(*args, **kwargs)
     # Param helper
     def get_probe_params(self, *args, **kwargs):
         if not self.active_probe:
-            raise self.printer.command_error("Cannot query endstop - no active tool probe.")
+            raise self.printer.command_error("Cannot query probe params - no active tool probe.")
         return self.active_probe.param_helper.get_probe_params(*args, **kwargs)
 
 # Routes commands to the selected tool probe endstop.
@@ -226,23 +251,6 @@ class EndstopRouter:
 
     def set_active_mcu(self, mcu_probe):
         self.active_mcu = mcu_probe
-        # Update Wrappers
-        if self.active_mcu:
-            self.get_mcu = self.active_mcu.get_mcu
-            self.home_start = self.active_mcu.home_start
-            self.home_wait = self.active_mcu.home_wait
-            self.multi_probe_begin = self.active_mcu.multi_probe_begin
-            self.multi_probe_end = self.active_mcu.multi_probe_end
-            self.probe_prepare = self.active_mcu.probe_prepare
-            self.probe_finish = self.active_mcu.probe_finish
-        else:
-            self.get_mcu = self.on_error
-            self.home_start = self.on_error
-            self.home_wait = self.on_error
-            self.multi_probe_begin = self.on_error
-            self.multi_probe_end = self.on_error
-            self.probe_prepare = self.on_error
-            self.probe_finish = self.on_error
 
     def add_stepper(self, stepper):
         self._steppers.append(stepper)
@@ -251,8 +259,6 @@ class EndstopRouter:
     def get_steppers(self):
         return list(self._steppers)
 
-    def on_error(self, *args, **kwargs):
-        raise self.printer.command_error("Cannot interact with probe - no active tool probe.")
     def query_endstop(self, print_time):
         if not self.active_mcu:
             raise self.printer.command_error("Cannot query endstop - no active tool probe.")
@@ -262,7 +268,12 @@ class EndstopRouter:
             # This will get picked up by the endstop, and is static
             # Report 0 and fix up in the homing sequence
             return 0.0
-        return self.active_mcu.get_position_endstop()
+        return 0.0
+
+    def start_probe_session(self, gcmd):
+        if not self.active_mcu:
+            raise self.printer.command_error("Cannot start probe session - no active tool probe.")
+        return self.active_mcu.start_probe_session(gcmd)
 
 def load_config(config):
     return ToolProbeEndstop(config)


### PR DESCRIPTION
## Summary

Updates the tool probe integration for recent Klipper probe API changes.

Recent Klipper versions changed the internal probe virtual-endstop and probe-session APIs. With current Klipper, klipper-toolchanger can fail during startup with:

```text
Internal error during connect: __init__() takes from 3 to 4 positional arguments but 5 were given
```

This updates the tool probe code to use the current probe API:

- Pass `ProbeOffsetsHelper` and `ProbeParameterHelper` to `ProbeEndstopWrapper`
- Replace `ProbeSessionHelper` with `SampleAveragingHelper`
- Route probe sessions to the currently active tool probe
- Use Klipper's standard `HomingViaProbeHelper` to register `probe:z_virtual_endstop`
- Remove obsolete MCU-endstop proxy bindings that current `ProbeEndstopWrapper` no longer exposes

Current Klipper uses `get_position_endstop` only to identify virtual-probe homing; the active probe session supplies the actual per-tool probe offset. Therefore the standard helper can use a static marker value while probe results remain dynamically routed through the active tool probe.

## Testing

Validated on a toolchanger printer running current Klipper. Standalone Z homing and print-start probing correctly respect the active tool probe offset after removing an unrelated legacy config-level coordinate override.

Also validated against upstream Klipper `2fb3d54e2` and ran:

```bash
python3 -m py_compile klipper/extras/tool_probe.py klipper/extras/tool_probe_endstop.py
git diff --check origin/main...HEAD
```