### PR TITLE
Improve idex probe support

### DIFF
--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -383,7 +383,7 @@ class ProbeEndstopWrapper:
             elif self.axis in ['x', 'y']:
                 name = stepper.get_name()
                 # Klipper internal names are usually 'stepper x', 'stepper u', etc.
-                if any(s in name for s in ['stepper x', 'stepper y', 'stepper u', 'stepper v']):
+                if any(s in name for s in ['stepper x', 'stepper x1', 'stepper x2', 'stepper x3', 'stepper y', 'stepper y1', 'stepper y2', 'stepper y3', 'stepper u', 'stepper u1', 'stepper v','stepper v1']):                
                     self.add_stepper(stepper)
 
     def get_position_endstop(self):

--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -380,10 +380,37 @@ class ProbeEndstopWrapper:
             # 2. Force registration for Dual-CoreXY IDEX
             # If we are wrapping the X or Y axis, we must register all
             # horizontal motors (x, y, u, v) to the stop-list.
+            # 
+            # is_active_axis in klipper only understands x, y, or z
+            # so if your axis is u or v then is_active_axis will always return false.
+            #
+            # This is very likely if you have an IDEX which has dual_carriage u
+            # for example (the self.axis here is still called x and y)
+            #
+            # If you don't do this, you will just run past the probe 
+            # without stopping your steppers, to the maximum probe distance.
             elif self.axis in ['x', 'y']:
                 name = stepper.get_name()
                 # Klipper internal names are usually 'stepper x', 'stepper u', etc.
-                if any(s in name for s in ['stepper x', 'stepper x1', 'stepper x2', 'stepper x3', 'stepper y', 'stepper y1', 'stepper y2', 'stepper y3', 'stepper u', 'stepper u1', 'stepper v','stepper v1']):                
+                # We know we need at least 'stepper x', 'stepper y', 'stepper u' and
+                # 'stepper v' (depending on which way round the u and x carriage are
+                # defined...) and we have guessed some other likely names.
+                #
+                # It's probably fine to actually stop all the steppers when we hit
+                # the probe, but this gets things working for our test case with
+                # minimal blast radius.
+                if any(s in name for s in ['stepper x',
+                                           'stepper x1',
+                                           'stepper x2',
+                                           'stepper x3',
+                                           'stepper y',
+                                           'stepper y1',
+                                           'stepper y2',
+                                           'stepper y3',
+                                           'stepper u',
+                                           'stepper u1',
+                                           'stepper v',
+                                           'stepper v1']):                
                     self.add_stepper(stepper)
 
     def get_position_endstop(self):

--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -373,8 +373,18 @@ class ProbeEndstopWrapper:
     def _handle_mcu_identify(self):
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         for stepper in kin.get_steppers():
+            # 1. Standard registration (works for Z and T0 X/Y)
             if stepper.is_active_axis(self.axis):
                 self.add_stepper(stepper)
+
+            # 2. Force registration for Dual-CoreXY IDEX
+            # If we are wrapping the X or Y axis, we must register all
+            # horizontal motors (x, y, u, v) to the stop-list.
+            elif self.axis in ['x', 'y']:
+                name = stepper.get_name()
+                # Klipper internal names are usually 'stepper x', 'stepper u', etc.
+                if any(s in name for s in ['stepper x', 'stepper y', 'stepper u', 'stepper v']):
+                    self.add_stepper(stepper)
 
     def get_position_endstop(self):
         return 0.


### PR DESCRIPTION
When using tools_calibrate on a dual-corexy IDEX printer, we observed a problem probing with T1. The tool overshoots the probe without stopping the steppers.

We diagnosed this as a problem registering the steppers associated with the U carriage.

The attached candidate patch to _handle_mcu_identify in tools_calibrate.py describes the problem and addresses it by adding the steppers by name.

Please review, this may have unintended consequences, but it fixes probing (with a nudge) for our IDEX configuration.

Thanks to discord user spotless20 for reporting, testing, and for the corrected and extended list of likely stepper names.